### PR TITLE
Added requestGraph scorecards example

### DIFF
--- a/snippets/forge-graphql-sdk/get-component-scorecards-with-scores/README.md
+++ b/snippets/forge-graphql-sdk/get-component-scorecards-with-scores/README.md
@@ -1,0 +1,3 @@
+# How to use this
+
+Run this in your Compass Forge app as an example of retrieving information via the `requestGraph` method. Replace `COMPONENT-ID` with a valid [Compass component ARI](https://developer.atlassian.com/cloud/compass/config-as-code/manage-components-with-config-as-code/#find-a-component-s-id).

--- a/snippets/forge-graphql-sdk/get-component-scorecards-with-scores/get-component-scorecards-with-scores.ts
+++ b/snippets/forge-graphql-sdk/get-component-scorecards-with-scores/get-component-scorecards-with-scores.ts
@@ -1,0 +1,37 @@
+const scorecardsQuery = `query getComponentScorecardsWithScores($componentId: ID!) {
+    compass {
+      component(id: $componentId) {
+        __typename
+        ... on CompassComponent {
+          id
+          name
+  
+          scorecards {
+            id
+            name
+            importance
+
+            scorecardScore(query: { componentId: $componentId }) {
+              totalScore
+              maxTotalScore
+            }
+          }
+        }
+        ... on QueryError {
+          message
+          extensions {
+            statusCode
+            errorType
+          }
+        }
+      }
+    }
+  }`;
+  const variables = {
+    componentId: 'COMPONENT-ID',
+  };
+  const headers = { 'X-ExperimentalApi': 'compass-beta, compass-prototype' };
+  const req = await graphqlGateway.compass.api.asApp().requestGraph(scorecardsQuery, variables, headers);
+  const result = await req.json();
+
+  console.log(result.data.compass.component.scorecards);


### PR DESCRIPTION
Adds an example of using the `requestGraph` method to execute graphQL queries not included in the Forge SDK.