### PR TITLE
Bug fix on metric query

### DIFF
--- a/snippets/graphql/get-metric-values-for-component/README.md
+++ b/snippets/graphql/get-metric-values-for-component/README.md
@@ -2,7 +2,7 @@
 
 This query will retrieve all metric values for a given component.
 
-Replace `componentARI` below in the variables section with a valid [Compass component ARI](https://developer.atlassian.com/cloud/compass/config-as-code/manage-components-with-config-as-code/#find-a-component-s-id) in your site and execute the query. You can use [the GraphQL explorer](https://developer.atlassian.com/cloud/compass/graphql/explorer/) to run this query and explore [the Compass API](https://developer.atlassian.com/cloud/compass/graphql/) further.
+Replace `componentID` below in the variables section with a valid [Compass component ARI](https://developer.atlassian.com/cloud/compass/config-as-code/manage-components-with-config-as-code/#find-a-component-s-id) in your site and execute the query. You can use [the GraphQL explorer](https://developer.atlassian.com/cloud/compass/graphql/explorer/) to run this query and explore [the Compass API](https://developer.atlassian.com/cloud/compass/graphql/) further.
 
 ### Query
 

--- a/snippets/graphql/get-metric-values-for-component/README.md
+++ b/snippets/graphql/get-metric-values-for-component/README.md
@@ -7,9 +7,9 @@ Replace `componentARI` below in the variables section with a valid [Compass comp
 ### Query
 
 ```graphql
-query getAMetricValue {
+query getMetricValue($componentID: ID! {
   compass {
-    component(id: "$componentARI") {
+    component(id: $componentID) {
       ... on CompassComponent {
         metricSources(query: { first: 10 }) {
           ... on CompassComponentMetricSourcesConnection {
@@ -48,7 +48,7 @@ query getAMetricValue {
 
 ```
 {
-  "componentARI": "your-component-ari"
-  # "componentARI": "ari:cloud:compass:8c9fa0a4-58bf-4a52-a1c2-fb9d071abcbd:component/b17a5c71-52a9-4a98-a1a1-d3bdaba73178/01a7bf71-4cc2-4ab0-ad03-6aab38ec92ea"
+  "componentID": "your-component-ari"
+  # "componentID": "ari:cloud:compass:8c9fa0a4-58bf-4a52-a1c2-fb9d071abcbd:component/b17a5c71-52a9-4a98-a1a1-d3bdaba73178/01a7bf71-4cc2-4ab0-ad03-6aab38ec92ea"
 }
 ```

--- a/snippets/graphql/get-metric-values-for-component/getMetricValues.graphql
+++ b/snippets/graphql/get-metric-values-for-component/getMetricValues.graphql
@@ -1,6 +1,6 @@
-query getAMetricValue {
+query getAMetricValue($componentID) {
   compass {
-    component(id: "the-component-ari") {
+    component(id: $componentID) {
       ... on CompassComponent {
         metricSources(query: { first: 10 }) {
           ... on CompassComponentMetricSourcesConnection {


### PR DESCRIPTION
Fixed the query bug and renamed the variable from "componentARI" to "componentID" (keeps it consistent with other queries like get operations)