### PR TITLE
Add tag import hander and default backstage import label

### DIFF
--- a/snippets/scripts/convert-backstage-config/backstage.yaml
+++ b/snippets/scripts/convert-backstage-config/backstage.yaml
@@ -6,6 +6,9 @@ metadata:
   description: This API enables CRUD operations on the Compass Test App
   labels:
     tier: "2"
+  tags:
+    - compass
+    - test-app
   links:
     - url: https://bitbucket.org/atlassian-test/compass-test-repo
       title: Repository Link

--- a/snippets/scripts/convert-backstage-config/compass.yaml
+++ b/snippets/scripts/convert-backstage-config/compass.yaml
@@ -3,6 +3,10 @@ description: This API enables CRUD operations on the Compass Test App
 fields:
   lifecycle: Pre-Release
   tier: 2
+labels:
+- compass
+- test-app
+- imported:backstage
 links:
 - name: Repository Link
   type: REPOSITORY

--- a/snippets/scripts/convert-backstage-config/convert_handlers.py
+++ b/snippets/scripts/convert-backstage-config/convert_handlers.py
@@ -115,11 +115,26 @@ def handle_type(value):
     return component_type_mappings.get(value.lower(), "SERVICE")
 
 
+def handle_labels(value):
+    """
+    Convert the labels from Backstage to Compass format.
+
+    :param value: The list of tags from Backstage.
+    :return: The labels in Compass format.
+    """
+    # Tagging all components as imported from Backstage
+    value += ["imported:backstage"]
+
+    # Compass has a limit of 10 labels per component
+    return value[:10]
+
+
 FIELD_HANDLERS = {
     "handle_name": handle_name,
     "handle_description": handle_description,
     "handle_lifecycle": handle_lifecycle,
     "handle_links": handle_links,
     "handle_tier": handle_tier,
-    "handle_type": handle_type
+    "handle_type": handle_type,
+    "handle_labels": handle_labels,
 }

--- a/snippets/scripts/convert-backstage-config/convert_to_compass.py
+++ b/snippets/scripts/convert-backstage-config/convert_to_compass.py
@@ -21,6 +21,7 @@ MAPPINGS = {
     "metadata.description": {"path": "description", "handler": "handle_description"},
     "metadata.labels.tier": {"path": "fields.tier", "handler": "handle_tier"},
     "metadata.links": {"path": "links", "handler": "handle_links"},
+    "metadata.tags": {"path": "labels", "handler": "handle_labels"},
     "spec.lifecycle": {"path": "fields.lifecycle", "handler": "handle_lifecycle"},
     "spec.type": {"path": "typeId", "handler": "handle_type"},
 }
@@ -64,7 +65,8 @@ def map_properties(input_data):
     # Start with default config data
     output_data = {
         "configVersion": 1,
-        "fields": {}
+        "fields": {},
+        "labels": ["imported:backstage"]
     }
 
     for input_path, output_info in MAPPINGS.items():


### PR DESCRIPTION
Adds handler to convert Backstage tags to Compass labels. Appends a default import label for measuring usage metrics. Updated the sample YAML files in the repo. Tested the YAML validity by creating a managed component with it.

![image](https://github.com/atlassian-labs/compass-examples/assets/136633736/efdfe2fb-8848-4b80-81c7-3fd3bbf4a3b2)
