### PR TITLE
Add labels length restrictions

### DIFF
--- a/snippets/scripts/convert-backstage-config/convert_handlers.py
+++ b/snippets/scripts/convert-backstage-config/convert_handlers.py
@@ -122,8 +122,8 @@ def handle_labels(value):
     :param value: The list of tags from Backstage.
     :return: The labels in Compass format.
     """
-    # Tagging all components as imported from Backstage
-    value += ["imported:backstage"]
+    # Tagging all components as imported from Backstage and truncating the labels to 40 characters
+    value = [v[:40] for v in value if v is not None] + ["imported:backstage"]
 
     # Compass has a limit of 10 labels per component
     return value[:10]


### PR DESCRIPTION
Adjustment to limit each label length to 40 chars long per Compass whereas Backstage supports length of up to 63 chars.