### PR TITLE
Fix git hook error after dependency installation 

### DIFF
--- a/apps/sample-dataprovider-app-statuspage/package.json
+++ b/apps/sample-dataprovider-app-statuspage/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "compile": "tsc --noEmit",
-    "prepare": "husky install",
+    "prepare": "cd ../.. && husky install apps/sample-dataprovider-app-statuspage",
     "test": "jest",
     "lint": "yarn lint:eslint && yarn lint:prettier --check",
     "fix:prettier:and:lint": "yarn lint:prettier:fix && yarn lint:eslint:fix",


### PR DESCRIPTION
Husky is currently set to run in a nested directory that is not at the same level as the `.git` directory. it's a know error (see  [here](https://github.com/typicode/husky/issues/1084) and [here](https://focusedlabs.io/blog/never-forget-to-remember-with-husky-githooks)) and it was causing the installation process to terminate with Exit status 1 as in the below logs:
```
> husky install

.git can't be found (see https://git.io/Jc3F9)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! statuspage-example-app@1.0.0 prepare: `husky install`
npm ERR! Exit status 1
```
This PR fixes the issue by running the `prepare` command from the same level as the `.git` directory